### PR TITLE
B 17159 okta secret management

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -133,7 +133,7 @@ require LOGIN_GOV_SECRET_KEY "See 'DISABLE_AWS_VAULT_WRAPPER=1 AWS_REGION=us-gov
 # Okta.mil configuration
 
 # Tenant
-export OKTA_TENANT_ORG_URL=https://test-milmove.okta.mil
+require OKTA_TENANT_ORG_URL "See 'DISABLE_AWS_VAULT_WRAPPER=1 AWS_REGION=us-gov-west-1 aws-vault exec transcom-gov-dev -- chamber read app-devlocal okta-tenant-org-url'"
 export OKTA_TENANT_CALLBACK_PORT=443
 export OKTA_TENANT_CALLBACK_PROTOCOL=https
 

--- a/.envrc
+++ b/.envrc
@@ -130,6 +130,28 @@ export LOGIN_GOV_HOSTNAME="idp.int.identitysandbox.gov"
 
 require LOGIN_GOV_SECRET_KEY "See 'DISABLE_AWS_VAULT_WRAPPER=1 AWS_REGION=us-gov-west-1 aws-vault exec transcom-gov-dev -- chamber read app-devlocal login_gov_secret_key'"
 
+# Okta.mil configuration
+
+# Tenant
+export OKTA_TENANT_ORG_URL=https://test-milmove.okta.mil
+export OKTA_TENANT_CALLBACK_PORT=443
+export OKTA_TENANT_CALLBACK_PROTOCOL=https
+
+# Customer
+require OKTA_CUSTOMER_SECRET_KEY "See 'DISABLE_AWS_VAULT_WRAPPER=1 AWS_REGION=us-gov-west-1 aws-vault exec transcom-gov-dev -- chamber read app-devlocal okta-customer-secret-key'"
+export OKTA_CUSTOMER_CLIENT_ID=0oa3jalqz3iCyRT9i0k6
+export OKTA_CUSTOMER_CALLBACK_URL=http://milmovelocal:3000/auth/login-gov/callback
+
+# Office
+require OKTA_OFFICE_SECRET_KEY "See 'DISABLE_AWS_VAULT_WRAPPER=1 AWS_REGION=us-gov-west-1 aws-vault exec transcom-gov-dev -- chamber read app-devlocal okta-office-secret-key'"
+export OKTA_OFFICE_CLIENT_ID=0oa3j8zgqkIUDrhOy0k6
+export OKTA_OFFICE_CALLBACK_URL=http://officelocal:3000/auth/login-gov/callback
+
+# Admin
+require OKTA_ADMIN_SECRET_KEY "See 'DISABLE_AWS_VAULT_WRAPPER=1 AWS_REGION=us-gov-west-1 aws-vault exec transcom-gov-dev -- chamber read app-devlocal okta-admin-secret-key'"
+export OKTA_ADMIN_CLIENT_ID=0oa3j9kbaTicDz0az0k6
+export OKTA_ADMIN_CALLBACK_URL=http://adminlocal:3000/auth/login-gov/callback
+
 # JSON Web Token (JWT) config
 CLIENT_AUTH_SECRET_KEY=$(cat config/tls/devlocal-client_auth_secret.key)
 export CLIENT_AUTH_SECRET_KEY

--- a/pkg/cli/auth.go
+++ b/pkg/cli/auth.go
@@ -39,33 +39,52 @@ const (
 	// LoginGovHostnameFlag is the Login.gov Hostname Flag
 	LoginGovHostnameFlag string = "login-gov-hostname"
 
-	// ! Verify wording after changes
+	// Okta flags for local development environment that serves test-milmove.okta.mil
 	// Okta tenant flags
-	/*
-		OktaTenantIssuerURLFlag    string = "okta-tenant-issuer-url"
-		OktaTenantCallbackPortFlag string = "okta-tenant-callback-port"
-	*/
+	OktaTenantOrgURLFlag string = "okta-tenant-org-url"
+	// OktaTenantCallbackPortFlag is the test-milmove Callback Port Flag
+	OktaTenantCallbackPortFlag string = "okta-tenant-callback-port"
+	// OktaTenantCallbackPortFlag is the test-milmove Callback Protocol Flag
+	OktaTenantCallbackProtocolFlag string = "okta-tenant-callback-protocol"
+
 	// Okta Customer client id and secret flags
-	/*
-		OktaCustomerSecretKeyFlag        string = "okta-customer-secret-key"
-		OktaCustomerClientIDFlag         string = "okta-customr-client-id"
-		OktaCustomerHostnameFlag         string = "okta-customer-hostname"
-		OktaCustomerCallbackProtocolFlag string = "okta-customer-callback-protocol"
-	*/
+	OktaCustomerClientIDFlag string = "okta-customer-client-id"
+	// RA Summary: gosec - G101 - Password Management: Hardcoded Password
+	// RA: This line was flagged because of use of the word "secret"
+	// RA: This line is used to identify the name of the flag. OktaCustomerSecretKeyFlag is the Okta Customer Application Secret Key Flag.
+	// RA: This value of this variable does not store an application secret.
+	// RA Developer Status: RA Request
+	// RA Validator Status:
+	// RA Validator:
+	// RA Modified Severity:
+	// #nosec G101
+	OktaCustomerSecretKeyFlag string = "okta-customer-secret-key"
+
 	// Okta Office client id and secret flags
-	/*
-		OktaOfficeSecretKeyFlag        string = "okta-office-secret-key"
-		OktaOfficeClientIDFlag         string = "okta-office-client-id"
-		OktaOfficeHostnameFlag         string = "okta-office-hostname"
-		OktaOfficeCallbackProtocolFlag string = "okta-office-callback-protocol"
-	*/
+	OktaOfficeClientIDFlag string = "okta-office-client-id"
+	// RA Summary: gosec - G101 - Password Management: Hardcoded Password
+	// RA: This line was flagged because of use of the word "secret"
+	// RA: This line is used to identify the name of the flag. OktaOfficeSecretKeyFlag is the Okta Office Application Secret Key Flag.
+	// RA: This value of this variable does not store an application secret.
+	// RA Developer Status: RA Request
+	// RA Validator Status:
+	// RA Validator:
+	// RA Modified Severity:
+	// #nosec G101
+	OktaOfficeSecretKeyFlag string = "okta-office-secret-key"
+
 	// Okta Admin client id and secret flags
-	/*
-		OktaAdminSecretKeyFlag        string = "okta-admin-secret-key"
-		OktaAdminClientIDFlag         string = "okta-admin-client-id"
-		OktaAdminHostnameFlag         string = "okta-admin-hostname"
-		OktaAdminCallbackProtocolFlag string = "okta-admin-callback-protocol"
-	*/
+	OktaAdminClientIDFlag string = "okta-admin-client-id"
+	// RA Summary: gosec - G101 - Password Management: Hardcoded Password
+	// RA: This line was flagged because of use of the word "secret"
+	// RA: This line is used to identify the name of the flag. OktaAdminSecretKeyFlag is the Okta Admin Application Secret Key Flag.
+	// RA: This value of this variable does not store an application secret.
+	// RA Developer Status: RA Request
+	// RA Validator Status:
+	// RA Validator:
+	// RA Modified Severity:
+	// #nosec G101
+	OktaAdminSecretKeyFlag string = "okta-admin-secret-key"
 )
 
 type errInvalidClientID struct {
@@ -91,7 +110,7 @@ func InitAuthFlags(flag *pflag.FlagSet) {
 	// TODO: Replace Okta os.Getenv
 
 	// // Okta flags
-	// flag.String(OktaTenantIssuerURLFlag, os.Getenv("OKTA_TENANT_ISSUER_URL"), "Okta tenant issuer URL.")
+	// flag.String(OktaTenantIssuerURLFlag, os.Getenv("OKTA_TENANT_ORG_URL"), "Okta tenant issuer URL.")
 	// flag.Int(OktaTenantCallbackPortFlag, 443, "Okta tenant callback port.")
 
 	// // Customer flags

--- a/pkg/handlers/authentication/okta/provider.go
+++ b/pkg/handlers/authentication/okta/provider.go
@@ -144,26 +144,25 @@ func wrapOktaProvider(provider *gothOkta.Provider, logger *zap.Logger) *Provider
 }
 
 // Function to register all three providers at once.
-// TODO: Use viper instead of os environment variables
 func (op *Provider) RegisterProviders() error {
 
 	// Declare OIDC scopes to be used within the providers
 	scope := []string{"openid", "email", "profile"}
 
-	// Register customer provider
-	err := op.RegisterOktaProvider(MilProviderName, os.Getenv("OKTA_CUSTOMER_HOSTNAME"), os.Getenv("OKTA_CUSTOMER_CALLBACK_URL"), os.Getenv("OKTA_CUSTOMER_CLIENT_ID"), os.Getenv("OKTA_CUSTOMER_SECRET_KEY"), scope)
+	// Register customer provider and pull values from env variables
+	err := op.RegisterOktaProvider(MilProviderName, os.Getenv("OKTA_TENANT_ORG_URL"), os.Getenv("OKTA_CUSTOMER_CALLBACK_URL"), os.Getenv("OKTA_CUSTOMER_CLIENT_ID"), os.Getenv("OKTA_CUSTOMER_SECRET_KEY"), scope)
 	if err != nil {
 		op.logger.Error("Could not register customer okta provider", zap.Error(err))
 		return err
 	}
 	// Register office provider
-	err = op.RegisterOktaProvider(OfficeProviderName, os.Getenv("OKTA_OFFICE_HOSTNAME"), os.Getenv("OKTA_OFFICE_CALLBACK_URL"), os.Getenv("OKTA_OFFICE_CLIENT_ID"), os.Getenv("OKTA_OFFICE_SECRET_KEY"), scope)
+	err = op.RegisterOktaProvider(OfficeProviderName, os.Getenv("OKTA_TENANT_ORG_URL"), os.Getenv("OKTA_OFFICE_CALLBACK_URL"), os.Getenv("OKTA_OFFICE_CLIENT_ID"), os.Getenv("OKTA_OFFICE_SECRET_KEY"), scope)
 	if err != nil {
 		op.logger.Error("Could not register office okta provider", zap.Error(err))
 		return err
 	}
 	// Register admin provider
-	err = op.RegisterOktaProvider(AdminProviderName, os.Getenv("OKTA_ADMIN_HOSTNAME"), os.Getenv("OKTA_ADMIN_CALLBACK_URL"), os.Getenv("OKTA_ADMIN_CLIENT_ID"), os.Getenv("OKTA_ADMIN_SECRET_KEY"), scope)
+	err = op.RegisterOktaProvider(AdminProviderName, os.Getenv("OKTA_TENANT_ORG_URL"), os.Getenv("OKTA_ADMIN_CALLBACK_URL"), os.Getenv("OKTA_ADMIN_CLIENT_ID"), os.Getenv("OKTA_ADMIN_SECRET_KEY"), scope)
 	if err != nil {
 		op.logger.Error("Could not register admin okta provider", zap.Error(err))
 		return err


### PR DESCRIPTION
## [B-17159](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3A825453)

## Summary

Updated `.envrc` with Okta client IDs, secrets, and okta tenant URL (secrets & tenant URL in chamber) for local dev environment that serves:
milmovelocal:3000/
officelocal:3000/
adminlocal:3000/

Followed these instructions in Confluence to manage secrets: https://dp3.atlassian.net/wiki/spaces/MT/pages/1249542242/0030+How+to+Manage+Secrets+with+Chamber

### Setup to Run the Code

NOTE: if you are getting `AWS_PROFILE: unbound variable`, try running `export AWS_PROFILE=transcom-gov-dev`

1. Run `make client_run` and `make server_run` in separate terminals
2. Sign in as either customer/office/admin & accept terms
3. You will be redirected to Okta login
4. Sign in or sign up
5. You will be redirected back to MilMove (currently getting `Internal Server Error` due to incomplete session management), but this does verify proper management of secrets and client ids for each MilMove application.

### How to test

**Automated testing is currently on hold until remaining login features are implemented**

- In order to test the changes, you will need to have access to aws-chamber and run `chamber list app-devlocal` in your terminal to see the listed secrets.
- To read each secret:
`chamber read app-devlocal okta-customer-secret-key`
`chamber read app-devlocal okta-office-secret-key`
`chamber read app-devlocal okta-admin-secret-key`

### Backend

- [x] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/about/development/logging).
