### PR TITLE
B-17237 MilMove Okta Profile Validation

### DIFF
--- a/src/components/Customer/EditOktaInfoForm/EditOktaInfoForm.jsx
+++ b/src/components/Customer/EditOktaInfoForm/EditOktaInfoForm.jsx
@@ -2,7 +2,6 @@ import classnames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Formik } from 'formik';
-// import * as Yup from 'yup';
 import { Link } from 'react-router-dom';
 
 import oktaLogo from '../../../shared/images/okta_logo.png';
@@ -15,23 +14,16 @@ import WizardNavigation from 'components/Customer/WizardNavigation/WizardNavigat
 import { Form } from 'components/form/Form';
 import formStyles from 'styles/form.module.scss';
 import { OktaInfoFields } from 'components/form/OktaInfoFields';
+import { oktaInfoSchema } from 'utils/validation';
 
 const EditOktaInfoForm = ({ initialValues, onSubmit, onCancel }) => {
-  // TODO need to add a validation schema to the form -- leaving what was previously here
-  // const validationSchema = Yup.object().shape({
-  //   ...contactInfoSchema.fields,
-  //   [residentialAddressName]: requiredAddressSchema.required(),
-  //   [backupAddressName]: requiredAddressSchema.required(),
-  //   [backupContactName]: backupContactInfoSchema.required(),
-  // });
-
   const sectionStyles = classnames(formStyles.formSection, editOktaInfoFormStyle.formSection);
   const url = isProduction
     ? 'https://milmove.okta.mil/enduser/settings'
     : 'https://test-milmove.okta.mil/enduser/settings';
 
   return (
-    <Formik initialValues={initialValues} onSubmit={onSubmit} validateOnMount>
+    <Formik initialValues={initialValues} onSubmit={onSubmit} validateOnMount validationSchema={oktaInfoSchema}>
       {({ isValid, isSubmitting, handleSubmit }) => {
         return (
           <Form className={classnames(formStyles.form, editOktaInfoFormStyle.form)}>

--- a/src/components/Customer/EditOktaInfoForm/EditOktaInfoForm.test.jsx
+++ b/src/components/Customer/EditOktaInfoForm/EditOktaInfoForm.test.jsx
@@ -1,0 +1,135 @@
+import React from 'react';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import EditOktaInfoForm from './EditOktaInfoForm';
+
+import { renderWithRouter } from 'testUtils';
+
+describe('EditOktaInfoForm component', () => {
+  const testProps = {
+    initialValues: {
+      oktaUsername: 'user@okta.mil',
+      oktaEmail: 'user@okta.mil',
+      oktaFirstName: 'Lucky',
+      oktaLastName: 'Shamrock',
+      oktaEdipi: '1112223334',
+    },
+    onSubmit: jest.fn().mockImplementation(() => Promise.resolve()),
+    onCancel: jest.fn(),
+  };
+
+  it('renders the form inputs', async () => {
+    renderWithRouter(<EditOktaInfoForm {...testProps} />);
+
+    const oktaUsername = await screen.findByLabelText('Okta Username');
+    expect(oktaUsername).toBeInstanceOf(HTMLInputElement);
+    expect(oktaUsername).toHaveValue(testProps.initialValues.oktaUsername);
+
+    const oktaEmail = await screen.findByLabelText('Okta Email');
+    expect(oktaEmail).toBeInstanceOf(HTMLInputElement);
+    expect(oktaEmail).toHaveValue(testProps.initialValues.oktaEmail);
+
+    const oktaFirstName = await screen.findByLabelText('First Name');
+    expect(oktaFirstName).toBeInstanceOf(HTMLInputElement);
+    expect(oktaFirstName).toHaveValue(testProps.initialValues.oktaFirstName);
+
+    const oktaLastName = await screen.findByLabelText('Last Name');
+    expect(oktaLastName).toBeInstanceOf(HTMLInputElement);
+    expect(oktaLastName).toHaveValue(testProps.initialValues.oktaLastName);
+
+    const oktaEdipi = await screen.findByLabelText('DoD ID number | EDIPI');
+    expect(oktaEdipi).toBeInstanceOf(HTMLInputElement);
+    expect(oktaEdipi).toHaveValue(testProps.initialValues.oktaEdipi);
+  });
+
+  it('shows an error message if Okta Username is empty', async () => {
+    renderWithRouter(<EditOktaInfoForm {...testProps} />);
+
+    const saveButton = await screen.findByRole('button', { name: 'Save' });
+    expect(saveButton).toBeEnabled();
+
+    const emailInput = await screen.findByLabelText('Okta Username');
+    await userEvent.clear(emailInput);
+    await userEvent.tab();
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toBeInTheDocument();
+    expect(alert).toHaveTextContent('Required');
+
+    expect(saveButton).toBeDisabled();
+  });
+
+  it('shows an error message if Okta Username is not in email format', async () => {
+    renderWithRouter(<EditOktaInfoForm {...testProps} />);
+
+    const emailInput = await screen.findByLabelText('Okta Username');
+    await userEvent.clear(emailInput);
+    await userEvent.type(emailInput, 'oktaUserWithoutEmail');
+    await userEvent.tab();
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toBeInTheDocument();
+    expect(alert).toHaveTextContent('Must be in email format');
+  });
+
+  it('shows an error message if Okta Email is empty', async () => {
+    renderWithRouter(<EditOktaInfoForm {...testProps} />);
+
+    const saveButton = await screen.findByRole('button', { name: 'Save' });
+    expect(saveButton).toBeEnabled();
+
+    const emailInput = await screen.findByLabelText('Okta Email');
+    await userEvent.clear(emailInput);
+    await userEvent.tab();
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toBeInTheDocument();
+    expect(alert).toHaveTextContent('Required');
+
+    expect(saveButton).toBeDisabled();
+  });
+
+  it('shows an error message if Okta Email is not in email format', async () => {
+    renderWithRouter(<EditOktaInfoForm {...testProps} />);
+
+    const emailInput = await screen.findByLabelText('Okta Email');
+    await userEvent.clear(emailInput);
+    await userEvent.type(emailInput, 'Not an email');
+    await userEvent.tab();
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toBeInTheDocument();
+    expect(alert).toHaveTextContent('Invalid email');
+  });
+
+  it('submits the form when its valid', async () => {
+    renderWithRouter(<EditOktaInfoForm {...testProps} />);
+
+    const saveButton = screen.getByRole('button', { name: 'Save' });
+
+    await userEvent.click(saveButton);
+
+    const expectedParams = {
+      ...testProps.initialValues,
+    };
+
+    await waitFor(() => {
+      expect(testProps.onSubmit).toHaveBeenCalledWith(expectedParams, expect.anything());
+    });
+  });
+
+  it('implements the onCancel handler when the Cancel button is clicked', async () => {
+    renderWithRouter(<EditOktaInfoForm {...testProps} />);
+
+    const cancelButton = screen.getByRole('button', { name: 'Cancel' });
+
+    await userEvent.click(cancelButton);
+
+    await waitFor(() => {
+      expect(testProps.onCancel).toHaveBeenCalled();
+    });
+  });
+
+  afterEach(jest.resetAllMocks);
+});

--- a/src/components/form/OktaInfoFields/index.jsx
+++ b/src/components/form/OktaInfoFields/index.jsx
@@ -15,7 +15,7 @@ export const OktaInfoFields = ({ legend, className, render }) => {
     <Fieldset legend={legend} className={className}>
       {render(
         <>
-          <TextField label="Okta Username" name={usernameFieldName} id="oktaUsername" required />
+          <TextField isDisabled label="Okta Username" name={usernameFieldName} id="oktaUsername" required />
           <TextField label="Okta Email" name={emailFieldName} id="oktaEmail" required />
           <TextField label="First Name" name={firstNameFieldName} id="oktaFirstName" required />
           <TextField label="Last Name" name={lastNameFieldName} id="oktaLastName" required />

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -105,3 +105,12 @@ export const backupContactInfoSchema = Yup.object().shape({
   email: emailSchema.required('Required'),
   telephone: phoneSchema.required('Required'),
 });
+
+// EDIPI can be between 7-10 digits to account for USCG members who use EIN
+export const oktaInfoSchema = Yup.object().shape({
+  oktaUsername: Yup.string().email('Must be in email format').required('Required'),
+  oktaEmail: Yup.string().email('Invalid email').required('Required'),
+  oktaFirstName: Yup.string().required('Required'),
+  oktaLastName: Yup.string().required('Required'),
+  oktaEdipi: Yup.string().min(7, 'Must be between 7-10 digits').max(10, 'Cannot be more than 10 digits'),
+});

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -106,11 +106,15 @@ export const backupContactInfoSchema = Yup.object().shape({
   telephone: phoneSchema.required('Required'),
 });
 
+export const edipiMinErrorMsg = 'Must be between 7-10 digits';
+
+export const edipiMaxErrorMsg = 'Cannot be more than 10 digits in length';
+
 // EDIPI can be between 7-10 digits to account for USCG members who use EIN
 export const oktaInfoSchema = Yup.object().shape({
-  oktaUsername: Yup.string().email('Must be in email format').required('Required'),
+  oktaUsername: Yup.string().required('Required'),
   oktaEmail: Yup.string().email('Invalid email').required('Required'),
   oktaFirstName: Yup.string().required('Required'),
   oktaLastName: Yup.string().required('Required'),
-  oktaEdipi: Yup.string().min(7, 'Must be between 7-10 digits').max(10, 'Cannot be more than 10 digits'),
+  oktaEdipi: Yup.string().min(7, edipiMinErrorMsg).max(10, edipiMaxErrorMsg),
 });

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -107,13 +107,13 @@ export const backupContactInfoSchema = Yup.object().shape({
 });
 
 export const edipiMinErrorMsg = 'Must be between 7-10 digits';
-
 export const edipiMaxErrorMsg = 'Cannot be more than 10 digits in length';
+export const emailFormatErrorMsg = 'Cannot be more than 10 digits in length';
 
 // EDIPI can be between 7-10 digits to account for USCG members who use EIN
 export const oktaInfoSchema = Yup.object().shape({
   oktaUsername: Yup.string().required('Required'),
-  oktaEmail: Yup.string().email('Invalid email').required('Required'),
+  oktaEmail: Yup.string().email(emailFormatErrorMsg).required('Required'),
   oktaFirstName: Yup.string().required('Required'),
   oktaLastName: Yup.string().required('Required'),
   oktaEdipi: Yup.string().min(7, edipiMinErrorMsg).max(10, edipiMaxErrorMsg),


### PR DESCRIPTION
## [B-17237 Validation for MilMove Profile Information](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3A834326&RoomContext=TeamRoom%3A808731&concept=TeamRoom)

## Summary

Added Yup validation schema to Okta Profile Form in MilMove. It checks the following:
- [x] Okta username is in email format
- [x] Okta email is in email format
- [x] First name is required
- [x] Last name is required
- [x] EDIPI is optional, but when inputting it must be either blank or between 7-10 digits

If any of these forms do not meet the criteria, it will not allow submission of the form and throw an error.

### Setup to Run the Code

- Pull branch
- `make client_run`
- `make server_run`
- Sign in/register as customer
- Go to profile and scroll down
- Open Okta Profile edit form by clicking "Edit" link
- Input values
