### PR TITLE
B-17220-OKTA-LOGOUT

### DIFF
--- a/pkg/handlers/authentication/auth.go
+++ b/pkg/handlers/authentication/auth.go
@@ -473,7 +473,6 @@ func NewLogoutHandler(ac Context, hc handlers.HandlerConfig) LogoutHandler {
 	return logoutHandler
 }
 
-// !Needs to be finalized after sessions.
 func (h LogoutHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	appCtx := h.AppContextFromRequest(r)
 	if appCtx.Session() != nil {
@@ -490,6 +489,7 @@ func (h LogoutHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			// this is shown in a sample app here: https://github.com/okta/samples-golang/blob/master/okta-hosted-login/main.go
 			appCtx.Session().AccessToken = ""
 			appCtx.Session().IDToken = ""
+			// Remember, UserID is UUID; however, the Okta ID is not.
 			if appCtx.Session().UserID != uuid.Nil {
 				err := resetUserCurrentSessionID(appCtx)
 				if err != nil {
@@ -501,7 +501,7 @@ func (h LogoutHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				appCtx.Logger().Error("failed to destroy session")
 			}
 			auth.DeleteCSRFCookies(w)
-			appCtx.Logger().Info("user logged out")
+			appCtx.Logger().Info("user logged out of application")
 			fmt.Fprint(w, logoutURL)
 		} else {
 			// Can't log out of okta.mil without a token, redirect and let them re-auth
@@ -815,7 +815,6 @@ func (h CallbackHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case authorizationResultUnauthorized:
 		invalidPermissionsResponse(appCtx, h.HandlerConfig, h.Context, w, r)
 	case authorizationResultAuthorized:
-		// http.Redirect(w, r, "http://milmovelocal:3000/", http.StatusTemporaryRedirect)
 		http.Redirect(w, r, landingURL.String(), http.StatusTemporaryRedirect)
 	}
 }

--- a/pkg/handlers/authentication/okta/provider.go
+++ b/pkg/handlers/authentication/okta/provider.go
@@ -257,6 +257,12 @@ func (op *Provider) GetIssuerURL() string {
 func (op *Provider) GetLogoutURL() string {
 	return op.orgURL + "/oauth2/v1/logout"
 }
+func (op *Provider) GetRevokeURL() string {
+	return op.orgURL + "/oauth2/v1/revoke"
+}
+func (op *Provider) GetSessionsURL() string {
+	return op.orgURL + "/oauth2/v1/sessions"
+}
 func (op *Provider) GetJWKSURL() string {
 	return op.orgURL + "/oauth2/default/.well-known/jwks.json"
 }
@@ -273,28 +279,6 @@ func (op Provider) TokenURL(r *http.Request) string {
 
 	return tokenURL
 }
-
-// Leaving this here in case it needs to be used in the future
-// When authenticating with Okta, the sample app provided clears the sessions
-// We could potentially revoke the token in the future so a user has to reauthenticate after sign out
-// func (op Provider) LogoutURL(provider Provider, redirectURL string) (string, error) {
-// 	logoutPath, err := url.Parse(provider.GetLogoutURL())
-// 	if err != nil {
-// 		return "", err
-// 	}
-//  Parameters taken from https://developers.login.gov/oidc/#logout
-// 	params := url.Values{
-// 		"id_token_hint":            {provider.orgURL},
-// 		"post_logout_redirect_uri": {redirectURL},
-// 		"state":                    {generateNonce()},
-// 	}
-
-// 	logoutPath.RawQuery = params.Encode()
-// 	strLogoutPath := logoutPath.String()
-// 	op.logger.Info("Logout path", zap.String("strLogoutPath", strLogoutPath))
-
-// 	return strLogoutPath, nil
-// }
 
 func generateNonce() string {
 	nonceBytes := make([]byte, 64)

--- a/pkg/handlers/authentication/okta/provider.go
+++ b/pkg/handlers/authentication/okta/provider.go
@@ -255,7 +255,7 @@ func (op *Provider) GetIssuerURL() string {
 }
 
 func (op *Provider) GetLogoutURL() string {
-	return op.orgURL + "/oauth2/v1/logout"
+	return op.orgURL + "/oauth2/default/v1/logout"
 }
 func (op *Provider) GetRevokeURL() string {
 	return op.orgURL + "/oauth2/v1/revoke"

--- a/pkg/handlers/authentication/okta_auth_code_flow.go
+++ b/pkg/handlers/authentication/okta_auth_code_flow.go
@@ -175,5 +175,5 @@ func logoutOktaUser(provider *okta.Provider, idToken string, redirectURL string)
 		return fmt.Errorf("failed to logout, status: %v, body: %s", resp.Status, string(bodyBytes))
 	}
 
-	return err
+	return nil
 }

--- a/pkg/handlers/authentication/okta_auth_code_flow.go
+++ b/pkg/handlers/authentication/okta_auth_code_flow.go
@@ -132,48 +132,25 @@ type Exchange struct {
 
 // logging a user out of okta requires calling the /logout API endpoint
 // it is a GET request and clears the browser session
-// a user will need to re-authenticate upon logging back in
-func logoutOktaUser(provider *okta.Provider, idToken string, redirectURL string) error {
-
+// the URL will need to be built using the ID token and a redirect URI
+func logoutOktaUserURL(provider *okta.Provider, idToken string, redirectURL string) (string, error) {
 	// baseURL will end in /logout
 	baseURL := provider.GetLogoutURL()
 
 	// Parse URL
 	logoutURL, err := url.Parse(baseURL)
 	if err != nil {
-		return fmt.Errorf("error parsing URL: %v", err)
+		return "", err
 	}
 
-	// add params required by Okta to successfully call the API
+	// add params required by Okta to successfully sign a user out
 	params := logoutURL.Query()
 	params.Set("id_token_hint", idToken)
-	params.Set("post_logout_redirect_uri", redirectURL)
+	params.Set("post_logout_redirect_uri", redirectURL+"sign-in")
 
 	logoutURL.RawQuery = params.Encode()
 
-	req, err := http.NewRequest("GET", logoutURL.String(), bytes.NewReader([]byte("")))
-	if err != nil {
-		return fmt.Errorf("error creating the request: %v", err)
-	}
-	h := req.Header
-	h.Add("Accept", "application/json")
-	h.Add("Content-Type", "application/json")
+	oktaLogoutURL := logoutURL.String()
 
-	client := &http.Client{}
-	resp, err := client.Do(req)
-	if err != nil {
-		return fmt.Errorf("error sending request: %v", err)
-	}
-	defer resp.Body.Close()
-
-	// if response code is not 200, then it was probably a bad request
-	if resp.StatusCode != 200 {
-		bodyBytes, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return fmt.Errorf("error reading response body: %v", err)
-		}
-		return fmt.Errorf("failed to logout, status: %v, body: %s", resp.Status, string(bodyBytes))
-	}
-
-	return nil
+	return oktaLogoutURL, err
 }


### PR DESCRIPTION
## [Okta Session Management](https://www13.v1host.com/USTRANSCOM38/story.mvc/Summary?oidToken=Story%3A824712&RoomContext=TeamRoom%3A808731&concept=TeamRoom)

## Summary

Upon signing out, a user is sent to Okta to logout from Okta in order to remove browser sessions. This then redirects a user back to MilMove where they can sign in again.

Note: this does remove the "You've signed out of MilMove banner" due to the user being directed to Okta, then directed back to MilMove, so unable to write in the action to display the logged out banner.

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Setup to Run the Code & Test

- Pull branch
- `make client_run`
- `make server_run`
- Log in as customer, office, or admin MilMove user
- Click "Sign Out" as customer, or "Log out" as office/admin
- Confirm you were successfully redirected to MilMove
- You can confirm your Okta session was cleared from the browser by going to the Okta domain and seeing if you need to log in (if it was not cleared your session would still exist and Okta would not need to verify you again in the browser)
